### PR TITLE
Conditional search bar

### DIFF
--- a/Api/src/Loaders/Company/arrayCompanies.js
+++ b/Api/src/Loaders/Company/arrayCompanies.js
@@ -4,7 +4,7 @@ const chance = new Chance();
 const fakeUserData = [
   [
     "jsarabialugo@gmail.com",
-    chance.company() + " company",
+    "Winn Dixie Stores Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -17,7 +17,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Avon Products, Inc." + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -30,7 +30,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Aon Corporation" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -43,7 +43,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Lam Research Corporation" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -56,7 +56,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Union Planters Corp" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -69,7 +69,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "NSTAR" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -82,7 +82,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Calpine Corp" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -95,7 +95,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "National Service Industries Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -108,7 +108,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "ALLETE, Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -121,7 +121,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Archer Daniels Midland" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -134,7 +134,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Harley-Davidson Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -147,7 +147,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Murphy Oil Corporation" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -160,7 +160,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Amerada Hess Corporation" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -173,7 +173,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Unified Western Grocers Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -186,7 +186,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "AdvancePCS, Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -199,7 +199,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "AmSouth Bancorp" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),
@@ -212,7 +212,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.company() + " company",
+    "Universal Forest Products Inc" + " company",
     chance.integer({ min: 10000000, max: 99999999 }),
     chance.name(),
     chance.address(),

--- a/Api/src/Loaders/User/arrayUser.js
+++ b/Api/src/Loaders/User/arrayUser.js
@@ -4,7 +4,7 @@ const chance = new Chance();
 const fakeUserData = [
   [
     "t0mshaster5@gmail.com",
-    chance.name(),
+    "Gregory Jenkins",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -17,7 +17,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Daisy Chavez",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -30,7 +30,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Catherine Lindsey",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -43,7 +43,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Daniel Tate",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -56,7 +56,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Donald Watson",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -69,7 +69,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Ronald Lamb",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -82,7 +82,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Philip Carpenter",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -95,7 +95,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Cole Kelly",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -108,7 +108,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Jerome Colon",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -121,7 +121,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Anthony Graham",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -134,7 +134,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Bobby Ramsey",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -147,7 +147,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Lilly Ray",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -160,7 +160,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Helen Russell",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -173,7 +173,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Patrick Thornton",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -186,7 +186,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Mario Fuentes",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -199,7 +199,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Eugenia Chavez",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -212,7 +212,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Genevieve Cole",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -225,7 +225,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Glen Holmes",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -238,7 +238,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Gussie McCarthy",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -251,7 +251,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Herbert Simpson",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -264,7 +264,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Howard Allison",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -277,7 +277,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Jeanette Franklin",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -290,7 +290,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Jesse Swanson",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -303,7 +303,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "John Valdez",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -316,7 +316,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Jonathan Singleton",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -329,7 +329,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Lucille Murray",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -342,7 +342,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Elizabeth Larson",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -355,7 +355,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Mamie Wheeler",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -368,7 +368,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Mark Stone",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -381,7 +381,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Max Cohen",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -394,7 +394,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Michael Drake",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -407,7 +407,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Mittie Gross",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -420,7 +420,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Nell Richardson",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -433,7 +433,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Olive Sandoval",
     "empleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -446,7 +446,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Ora Hunt",
     "desempleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -460,7 +460,7 @@ const fakeUserData = [
 
   [
     chance.email(),
-    chance.name(),
+    "Ralph Alvarez",
     "desempleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -473,7 +473,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Tom Lindsey",
     "desempleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -486,7 +486,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Vernon Smith",
     "desempleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -499,7 +499,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Willie Flowers",
     "desempleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),
@@ -512,7 +512,7 @@ const fakeUserData = [
   ],
   [
     chance.email(),
-    chance.name(),
+    "Leona Henderson",
     "desempleado",
     chance.age(),
     chance.url({ extensions: ["jpg", "png"] }),

--- a/Client/src/Components/SearchBar/SearchBar.jsx
+++ b/Client/src/Components/SearchBar/SearchBar.jsx
@@ -41,12 +41,25 @@ function keyDownHandler(e, setSelected, selected, usersFiltered) {
 }
 
 export default function SearchBar() {
-  let usersList = useSelector((state) => [...state.users, ...state.companies]);
-  usersList = usersList.map((user) => user.name);
-  const [users, setUsers] = useState(usersList);
+  let MyUserAccount = useSelector((state) => state.myUser)
+  let myCompany = useSelector((state) => state.myCompany)
+  let onlyUsers = useSelector((state) => state.users);
+  let userNameList = onlyUsers.map((user) => user.name);
+  let onlyCompanies = useSelector((state) => state.companies);
+  let companyNameList = onlyCompanies.map((comp) => comp.name);
+  let usersList = [];
+
+  if (companyNameList?.includes(myCompany.name)) {//si es compañia
+    usersList = userNameList
+  }if(userNameList?.includes(MyUserAccount.name)){
+    usersList = companyNameList
+  }
+
+  const [users, setUsers] = useState(usersList);//usuarios a filtrar
   if (users.length < usersList.length) {
     setUsers(usersList);
   }
+
   const [usersFiltered, setUsersFiltered] = useState([]);
   const [focus, setFocus] = useState(false);
   const [nameUser, setNameUser] = useState(""); //estado que contendra el texto de la barra de busqueda
@@ -60,19 +73,28 @@ export default function SearchBar() {
 
   function submitHandler(e, userSelected, navigate, nameUsers, nameUser) {
     e.preventDefault();
-    let existUserInDB = nameUsers.includes(nameUser);
-    if (existUserInDB) {
-      navigate(`/users/${userSelected ? userSelected : nameUser}`);
-      
-      getUserInfo(nameUser).then((action) => {
-        dispatch(action);
-      });
-      setNameUser("")
+    if (nameUsers.includes(nameUser)) {//el nombre buscado existe
+      if (companyNameList.includes(myCompany?.name)) {
+        console.log("soy compañia");//aca debe ir la accion que llama la data de la tabla de compañias
+        navigate(`/users/${userSelected ? userSelected : nameUser}`);
+        getUserInfo(nameUser).then((action) => {
+          dispatch(action);
+        });
+        setNameUser("")
+      }if(userNameList.includes(MyUserAccount?.name)){
+        console.log("soy usuario");
+        console.log(nameUser);
+        navigate(`/users/${userSelected ? userSelected : nameUser}`);
+        getUserInfo(nameUser).then((action) => {
+          dispatch(action);
+        });
+        setNameUser("")
+      }
     } else {
       swal({
         icon: 'error',
         title: 'Oops...',
-        text: 'Something went wrong!',
+        text: 'User not found!',
       })
     }
   }
@@ -82,6 +104,7 @@ export default function SearchBar() {
     getAllUsers().then((data) => dispatch(data));
     // eslint-disable-next-line
   }, []);
+  
   const [selected, setSelected] = useState(-1);
   const navigate = useNavigate();
 

--- a/Client/src/Pages/Users/Users.jsx
+++ b/Client/src/Pages/Users/Users.jsx
@@ -8,8 +8,6 @@ import axios from "axios";
 import Navbar from "../../Components/NavBar/NavBar";
 import { useAuth0 } from "@auth0/auth0-react";
 
-
-
 export default function Users() {
   // esto es para poder mokear la info ya que esta action se deberia de hacer
   // al hacer el login ya deberia de pasar la informacion al reducer.
@@ -23,7 +21,7 @@ export default function Users() {
     // console.log(state);
     return { ...state.user, postulates: [...state.postulatesUser], plans: [...state.activePlans] };
   });
-
+  
   console.log(userData);
   useEffect(() => {
     getUserInfo(username).then((action) => {


### PR DESCRIPTION
en el sembrado de companñias y usuarios quite los nombres aleatorios por unos por defecto para evitar algunos temas al cargar los nombres sean los mismos siempre. moifique la barra de busqueda para que segun el nombre de usuario que tenga sepa si es compañia o usuario, y e esa manera solo me permita buscar usuarios si soy una compañia y viceversa, a la vez que las recomendaciones de la barra de busqueda se muestren de esa misma manera. y cambie el texto del mensaje de sweetAlert